### PR TITLE
Feature/도현/network

### DIFF
--- a/MOMO/MOMO.xcodeproj/project.pbxproj
+++ b/MOMO/MOMO.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		285209F42753329600AB8BAC /* StoryboardInstantiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285209D92753329600AB8BAC /* StoryboardInstantiable.swift */; };
 		285209F52753329600AB8BAC /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285209DB2753329600AB8BAC /* StorageService.swift */; };
 		285209F62753329600AB8BAC /* InfoData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285209DD2753329600AB8BAC /* InfoData.swift */; };
+		286DDE192771ADC3003E9563 /* GenericResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286DDE182771ADC3003E9563 /* GenericResponse.swift */; };
 		288ED75A27427CC200C5178D /* BookmarkList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 288ED75927427CC200C5178D /* BookmarkList.storyboard */; };
 		288ED75C27427CD000C5178D /* BookmarkListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288ED75B27427CD000C5178D /* BookmarkListViewController.swift */; };
 		288ED76027427D5800C5178D /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288ED75E27427D5800C5178D /* ListTableViewCell.swift */; };
@@ -203,6 +204,7 @@
 		285209D92753329600AB8BAC /* StoryboardInstantiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardInstantiable.swift; sourceTree = "<group>"; };
 		285209DB2753329600AB8BAC /* StorageService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
 		285209DD2753329600AB8BAC /* InfoData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoData.swift; sourceTree = "<group>"; };
+		286DDE182771ADC3003E9563 /* GenericResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericResponse.swift; sourceTree = "<group>"; };
 		288ED75927427CC200C5178D /* BookmarkList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BookmarkList.storyboard; sourceTree = "<group>"; };
 		288ED75B27427CD000C5178D /* BookmarkListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkListViewController.swift; sourceTree = "<group>"; };
 		288ED75E27427D5800C5178D /* ListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
@@ -638,6 +640,7 @@
 				75CE01C927662CE00057CF9B /* APIable.swift */,
 				75BF0C0E276B851800C2D0C1 /* GetApi.swift */,
 				75BF0C10276CA01B00C2D0C1 /* PostApi.swift */,
+				286DDE182771ADC3003E9563 /* GenericResponse.swift */,
 			);
 			path = APIModel;
 			sourceTree = "<group>";
@@ -997,6 +1000,7 @@
 				28F4FE1927610E3800E699FC /* NotificationData.swift in Sources */,
 				285209C02753327200AB8BAC /* LoginViewController.swift in Sources */,
 				288ED76027427D5800C5178D /* ListTableViewCell.swift in Sources */,
+				286DDE192771ADC3003E9563 /* GenericResponse.swift in Sources */,
 				2852099E2753325F00AB8BAC /* WithTextViewController.swift in Sources */,
 				28F471412738B3090074D148 /* HomeMainViewController.swift in Sources */,
 				288EFD1D2755D41E000D1617 /* AlertTableViewCell.swift in Sources */,

--- a/MOMO/MOMO/Global/Custom/PopAnimator.swift
+++ b/MOMO/MOMO/Global/Custom/PopAnimator.swift
@@ -48,10 +48,6 @@ class PopAnimator: NSObject, UIViewControllerAnimatedTransitioning {
     
     UIView.animate(withDuration: duration) {
       recommendCell.transform = self.presenting ? CGAffineTransform.identity : scaleTransform
-      print(finalFrame)
-      print(initialFrame)
-      print("finalFrame.midx, midy", finalFrame.midX, finalFrame.midY)
-      print("initical.midx, midy", initialFrame.midX, initialFrame.midY)
       recommendCell.center = CGPoint(x: finalFrame.midX, y: finalFrame.midY)
     } completion: { _ in
       if !self.presenting {

--- a/MOMO/MOMO/Global/Model/APIModel/APIable.swift
+++ b/MOMO/MOMO/Global/Model/APIModel/APIable.swift
@@ -10,36 +10,41 @@ import Foundation
 import Foundation
 
 protocol APIable {
-    var contentType: ContentType { get }
-    var requestType: RequestType { get }
-    var url: String { get }
-    var param: [String: String?]? { get }
+  var contentType: ContentType { get }
+  var requestType: RequestType { get }
+  var encodingType: EncodingType {get}
+  var header: [String: String]? { get }
+  var url: String { get }
+  var param: [String: String?]? { get }
 }
 
 enum RequestType: String {
-    case get = "GET"
-    case post = "POST"
-    case delete = "DELETE"
-    case patch = "PATCH"
-    
-    var method: String {
-        return self.rawValue
-    }
+  case get = "GET"
+  case post = "POST"
+  case delete = "DELETE"
+  case patch = "PATCH"
+  
+  var method: String {
+    return self.rawValue
+  }
 }
 
 enum ContentType {
-    case multiPartForm
-    case jsonData
-    case noBody
-    
-    var description: String {
-        switch self {
-        case .multiPartForm:
-            return "multipart/form-data"
-        case .jsonData:
-            return "aplication/json"
-        case .noBody:
-            return ""
-        }
+  case multiPartForm
+  case jsonData
+  case urlEncoding
+  case noBody
+  
+  var description: String {
+    switch self {
+    case .multiPartForm:
+      return "multipart/form-data"
+    case .jsonData:
+      return "aplication/json"
+    case .urlEncoding:
+      return "application/x-www-form-urlencoded"
+    case .noBody:
+      return ""
     }
+  }
 }

--- a/MOMO/MOMO/Global/Model/APIModel/GenericResponse.swift
+++ b/MOMO/MOMO/Global/Model/APIModel/GenericResponse.swift
@@ -1,0 +1,30 @@
+//
+//  GenericResponse.swift
+//  MOMO
+//
+//  Created by abc on 2021/12/21.
+//
+
+import Foundation
+
+struct GenericResponse<T: Codable>: Codable {
+  var status: Int
+  var success: Bool
+  var message: String
+  var data: T?
+  
+  enum CodingKeys: String, CodingKey {
+    case status, success, message, data
+  }
+}
+
+extension GenericResponse {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.status = (try? container.decode(Int.self, forKey: .status)) ?? 400
+    self.success = (try? container.decode(Bool.self, forKey: .success.self)) ?? false
+    self.message = (try? container.decode(String.self, forKey: .message.self)) ?? " "
+    // data 값이 없ㄷㅏ면 nil 반환
+    self.data = (try? container.decode(T.self, forKey: .data.self)) ?? nil
+  }
+}

--- a/MOMO/MOMO/Global/Model/APIModel/GetApi.swift
+++ b/MOMO/MOMO/Global/Model/APIModel/GetApi.swift
@@ -5,13 +5,86 @@
 //  Created by 오승기 on 2021/12/16.
 //
 
+// 설명: GetAPI를 작성하는 곳이다.
+// encodingType에서는 URLEncoding 이나 JSONEncoding을 정한다. Path variable은 그냥 url에서 작성한다.
+// queryString일 경우에는 encodingType을 URLEncoding으로 작성한다.
+// header을 통해서 Bearer token을 추가해준다.
+// param을 통해서 req에 넘겨줄 데이터를 보여준다.
+
 import Foundation
 
-enum GetApi {
-    case login
-    case babyGet
-    case bookmarkGet
-    case communityGet
-    case communityDetailGet
-    //Infoget밑으로 안함
+enum GetApi: APIable {
+  
+  case login
+  case babyGet
+  case bookmarkGet
+  case communityGet
+  case communityDetailGet
+  case noticeGet
+  case policyGet(token: String, keyword: String?, location: String?, category: String?, page: String?)
+  //Infoget밑으로 안함
+}
+
+extension GetApi {
+  
+  var contentType: ContentType {
+    switch self {
+    case .noticeGet, .policyGet:
+      return .noBody
+    default:
+      return .noBody
+    }
+  }
+  
+  var encodingType: EncodingType {
+    switch self {
+    case .noticeGet:
+      return .JSONEncoding
+    case .policyGet:
+      return .URLEncoding
+    default:
+      return .URLEncoding
+    }
+  }
+  
+  var requestType: RequestType {
+    return .get
+  }
+  
+  var url: String {
+    switch self {
+    case .noticeGet:
+      return makePathtoURL(path: "/notice")
+    case .policyGet:
+      return makePathtoURL(path: "/policy")
+    default:
+      return " "
+    }
+  }
+  
+  var param: [String : String?]? {
+    switch self {
+    case .noticeGet:
+      return nil
+    case .policyGet(_, let keyword, let location, let category, let page):
+      return ["keyword": keyword, "location": location, "category": category, "page": page]
+    default:
+      return nil
+    }
+  }
+  
+  var header: [String : String]? {
+    switch self {
+    case .noticeGet:
+      return nil
+    case .policyGet(let token, _, _, _, _):
+      return [ "Authorization" : "Bearer \(token)"]
+    default:
+      return nil
+    }
+  }
+  
+  func makePathtoURL(path: String?) -> String {
+    return NetworkManager.baseUrl + "\(path ?? "")"
+  }
 }

--- a/MOMO/MOMO/Global/Model/APIModel/PostApi.swift
+++ b/MOMO/MOMO/Global/Model/APIModel/PostApi.swift
@@ -5,6 +5,14 @@
 //  Created by 오승기 on 2021/12/17.
 //
 
+// 설명: POSTAPI를 작성하는 곳이다.
+// encodingType에서는 URLEncoding 이나 JSONEncoding을 정한다. Path variable은 그냥 url에서 작성한다.
+// contentType에서는 웬만하면 다 application/json으로 갈 것이다.
+// 하지만 api 설계서에 urlencoding 방식이라면 contenttype이 urlencoding으로 하면된다.
+// queryString일 경우에는 encodingType을 URLEncoding으로 작성한다.
+// header을 통해서 Bearer token을 추가해준다.
+// param을 통해서 req에 넘겨줄 데이터를 보여준다.
+
 import Foundation
 
 enum PostApi: APIable {
@@ -37,7 +45,7 @@ enum PostApi: APIable {
     var url: String {
         switch self {
         case .registProfile:
-            return "http://localhost:5001/momo-test-a4b5f/asia-northeast3/api/auth/signup"
+            return makePathtoURL(path: "auth/signup")
         }
     }
     
@@ -60,5 +68,9 @@ enum PostApi: APIable {
     default:
       return nil
     }
+  }
+  
+  func makePathtoURL(path: String?) -> String {
+    return NetworkManager.baseUrl + "\(path ?? "")"
   }
 }

--- a/MOMO/MOMO/Global/Model/APIModel/PostApi.swift
+++ b/MOMO/MOMO/Global/Model/APIModel/PostApi.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum PostApi: APIable {
     case registProfile(email: String, password: String, nickname: String, isPregnant: Bool, hasChild: Bool, age: Int, location: String, contentType: ContentType)
+
     
     var contentType: ContentType {
         switch self {
@@ -16,6 +17,15 @@ enum PostApi: APIable {
             return contentType
         }
     }
+  
+  var encodingType: EncodingType {
+    switch self {
+    case .registProfile:
+      return .JSONEncoding
+    default:
+      return .JSONEncoding
+    }
+  }
     
     var requestType: RequestType {
         switch self {
@@ -44,4 +54,11 @@ enum PostApi: APIable {
                     ]
         }
     }
+  
+  var header: [String : String]? {
+    switch self {
+    default:
+      return nil
+    }
+  }
 }

--- a/MOMO/MOMO/Global/Model/BabyData.swift
+++ b/MOMO/MOMO/Global/Model/BabyData.swift
@@ -16,10 +16,7 @@ struct BabyData: Codable {
   let updatedAt: String
   
   enum CodingKeys: String, CodingKey {
-    case id, name, birth
-    case imageURL = "image_url"
-    case createdAt = "created_at"
-    case updatedAt = "updated_at"
+    case id, name, birth, imageURL, createdAt, updatedAt
   }
 }
 

--- a/MOMO/MOMO/Global/Model/InfoData.swift
+++ b/MOMO/MOMO/Global/Model/InfoData.swift
@@ -20,11 +20,7 @@ struct InfoData: simpleContent, Codable {
 
 extension InfoData{
   enum CodingKeys: String, CodingKey {
-    case id, author, title, url
-    case thumbnailImageUrl = "thumbnail_image_url"
-    case week
-    case createdAt = "created_at"
-    case updatedAt = "updated_at"
+    case id, author, title, url, thumbnailImageUrl, week, createdAt, updatedAt
   }
 }
 

--- a/MOMO/MOMO/Global/Model/LikeData.swift
+++ b/MOMO/MOMO/Global/Model/LikeData.swift
@@ -15,9 +15,7 @@ struct LikeData: Codable {
 
 extension LikeData {
   enum CodingKeys: String, CodingKey {
-    case commmunityData
-    case createdAt = "created_at"
-    case updatedAt = "updated_at"
+    case commmunityData, createdAt, updatedAt
   }
   
   init(from decoder: Decoder) throws {

--- a/MOMO/MOMO/Global/Model/NetworkManager.swift
+++ b/MOMO/MOMO/Global/Model/NetworkManager.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 enum NetworkError: Error {
-    case invalidURL
-    case failResponse
-    case invalidData
+  case invalidURL
+  case failResponse
+  case invalidData
 }
 
 protocol Networkable {
-    func dataTask(with request: URLRequest, completionHandler: @escaping(Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+  func dataTask(with request: URLRequest, completionHandler: @escaping(Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
 }
 
 extension URLSession: Networkable {}
@@ -22,108 +22,137 @@ extension URLSession: Networkable {}
 typealias URLSessionResult = ((Result<Data, Error>) -> Void)
 
 class NetworkManager {
-    static let baseUrl = ""
-    private let boundary = "Boundary-\(UUID().uuidString)"
-    private let parsingManager = ParsingManager()
-    private let session: Networkable
+  static let baseUrl = "https://asia-northeast3-momo-test-a4b5f.cloudfunctions.net/api"
+  private let boundary = "Boundary-\(UUID().uuidString)"
+  private let parsingManager = ParsingManager()
+  private let session: Networkable
+  
+  init(session: Networkable = URLSession.shared) {
+    self.session = session
+  }
+  
+  
+  func request(apiModel: APIable, completion: @escaping URLSessionResult) {
     
-    init(session: Networkable = URLSession.shared) {
-        self.session = session
+    var url: URL!
+    
+    switch apiModel.encodingType {
+    case .URLEncoding:
+      guard let tempUrl = parsingManager.URLEncoding(parameters: apiModel.param, url: apiModel.url) else {
+        completion(.failure(NetworkError.invalidURL))
+        return
+      }
+      url = tempUrl
+    case .JSONEncoding:
+      guard let tempUrl = URL(string: apiModel.url) else {
+        completion(.failure(NetworkError.invalidURL))
+        return
+      }
+      url = tempUrl
+    }
+   
+    var request = URLRequest(url: url)
+    request.httpMethod = apiModel.requestType.method
+    request.httpBody = createDataBody(parameter: apiModel.param, contentType: apiModel.contentType, url: apiModel.url)
+    
+    // 컨텐트 타입 추가
+    switch apiModel.contentType {
+    case .multiPartForm:
+      request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    case .jsonData:
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    case .urlEncoding:
+      request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+    case .noBody:
+      break
     }
     
-    func request(apiModel: APIable, completion: @escaping URLSessionResult) {
-        guard let url = URL(string: apiModel.url) else {
-            completion(.failure(NetworkError.invalidURL))
-            return
-        }
-        print("url=")
-        var request = URLRequest(url: url)
-        request.httpMethod = apiModel.requestType.method
-        request.httpBody = createDataBody(parameter: apiModel.param, contentType: apiModel.contentType)
-        
-        switch apiModel.contentType {
-        case .multiPartForm:
-            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        case .jsonData:
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        case .noBody:
-            break
-        }
-        
-        session.dataTask(with: request) { data, response, error in
-            if let error = error {
-                completion(.failure(error))
-                return
-            }
-            
-            guard let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode) else {
-                completion(.failure(NetworkError.failResponse))
-                return
-            }
-            
-            guard let data = data else {
-                completion(.failure(NetworkError.invalidData))
-                return
-            }
-            completion(.success(data))
-        } .resume()
+    // header 추가
+    if let header = apiModel.header {
+      header.forEach { request.addValue($1, forHTTPHeaderField: $0)}
     }
+    
+    session.dataTask(with: request) { data, response, error in
+      if let error = error {
+        completion(.failure(error))
+        return
+      }
+      
+      guard let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode) else {
+        completion(.failure(NetworkError.failResponse))
+        return
+      }
+      
+      guard let data = data else {
+        completion(.failure(NetworkError.invalidData))
+        return
+      }
+      completion(.success(data))
+    } .resume()
+  }
 }
 
 extension NetworkManager {
+  
+  private func createDataBody(parameter: [String: String?]?, contentType: ContentType, url: String) -> Data? {
+    var body = Data()
+    let lineBreak = "\r\n"
     
-    private func createDataBody(parameter: [String: String?]?, contentType: ContentType) -> Data? {
-        var body = Data()
-        let lineBreak = "\r\n"
-        
-        if let modelParameter = parameter {
-            if contentType == .multiPartForm {
-                for (key, value) in modelParameter {
-                    body.append(convertTextField(key: key, value: "\(value ?? "")"))
-                }
-                body.append("--\(boundary)--\(lineBreak)")
-            } else {
-                if let data = parsingManager.encodingModel(model: parameter){
-                    body = data
-                }
-            }
-        } else {
-            return nil
+    if let modelParameter = parameter {
+      switch contentType {
+      case .multiPartForm:
+        for (key, value) in modelParameter {
+          body.append(convertTextField(key: key, value: "\(value ?? "")"))
         }
-        return body
+        body.append("--\(boundary)--\(lineBreak)")
+      case .jsonData:
+        if let data = parsingManager.encodingModel(parameters: parameter){
+          body = data
+        }
+      case .urlEncoding:
+        if let data = parsingManager.URLEncodingModelWithQueryString(parameters: parameter, url: url){
+          body = data
+        }
+      case .noBody:
+        return nil
+      }
+      return body
+    } else {
+      return nil
     }
+  }
+  
+  private func convertFileField(key: String, source: String, mimeType: String, value: Data) -> Data {
+    let lineBreak = "\r\n"
+    var dataField = Data()
     
-    private func convertFileField(key: String, source: String, mimeType: String, value: Data) -> Data {
-        let lineBreak = "\r\n"
-        var dataField = Data()
-        
-        dataField.append("--\(boundary + lineBreak)")
-        dataField.append("Content-Disposition: form-data; name=\"\(key)\"; filename=\"\(source)\"\(lineBreak)")
-        dataField.append("Content-Type: \(mimeType + lineBreak + lineBreak)")
-        dataField.append(value)
-        dataField.append(lineBreak)
-        
-        return dataField
-    }
+    dataField.append("--\(boundary + lineBreak)")
+    dataField.append("Content-Disposition: form-data; name=\"\(key)\"; filename=\"\(source)\"\(lineBreak)")
+    dataField.append("Content-Type: \(mimeType + lineBreak + lineBreak)")
+    dataField.append(value)
+    dataField.append(lineBreak)
     
-    private func convertTextField(key: String, value: String) -> Data {
-        let lineBreak = "\r\n"
-        var textField = Data()
-        
-        textField.append("--\(boundary + lineBreak)")
-        textField.append("Content-Disposition: form-data; name=\"\(key)\"\(lineBreak + lineBreak)")
-        textField.append("\(value)\(lineBreak)")
-        
-        return textField
-    }
+    return dataField
+  }
+  
+  private func convertTextField(key: String, value: String) -> Data {
+    let lineBreak = "\r\n"
+    var textField = Data()
+    
+    textField.append("--\(boundary + lineBreak)")
+    textField.append("Content-Disposition: form-data; name=\"\(key)\"\(lineBreak + lineBreak)")
+    textField.append("\(value)\(lineBreak)")
+    
+    return textField
+  }
 }
 
 extension Data {
-    mutating func append(_ string: String) {
-        if let data = string.data(using: .utf8) {
-            append(data)
-        }
+  mutating func append(_ string: String) {
+    if let data = string.data(using: .utf8) {
+      append(data)
     }
+  }
 }
 
 

--- a/MOMO/MOMO/Global/Model/NoticeData.swift
+++ b/MOMO/MOMO/Global/Model/NoticeData.swift
@@ -18,8 +18,6 @@ struct NoticeData: Codable {
 
 extension NoticeData {
   enum CodingKeys: String, CodingKey {
-    case id, author, title, url
-    case createdAt = "created_at"
-    case updatedAt = "updated_at"
+    case id, author, title, url, createdAt, updatedAt
   }
 }

--- a/MOMO/MOMO/Global/Model/ParsingManager.swift
+++ b/MOMO/MOMO/Global/Model/ParsingManager.swift
@@ -8,21 +8,66 @@
 import Foundation
 
 enum JsonError: Error {
-    case decodingError
-    case encodingError
+  case decodingError
+  case encodingError
+}
+
+enum EncodingType {
+  case URLEncoding
+  case JSONEncoding
 }
 
 struct ParsingManager {
-    private let decoder = JSONDecoder()
-    private let encoder = JSONEncoder()
-    
-    func decodingData<T:Decodable>(data: Data, model: T.Type) -> T? {
-        let convertedModel = try? decoder.decode(T.self, from: data)
-        return convertedModel
+  private let decoder = JSONDecoder()
+  private let encoder = JSONEncoder()
+  
+  func decodingData<T:Decodable>(data: Data, model: T.Type) -> T? {
+    let convertedModel = try? decoder.decode(T.self, from: data)
+    return convertedModel
+  }
+  
+  func judgeGenericResponse<T: Codable>(data: Data, model: T.Type, completion: @escaping((T) -> Void)) {
+    let body = try? decoder.decode(GenericResponse<T>.self, from: data)
+    guard let bodyData = body?.data else {
+      return
     }
-    
-    func encodingModel(model: [String: String?]?) -> Data? {
-        let convertedData = try? encoder.encode(model)
-        return convertedData
+    completion(bodyData)
+  }
+  
+  
+  func encodingModel(parameters: [String: String?]?) -> Data? {
+    let convertedData = try? encoder.encode(parameters)
+    return convertedData
+  }
+  
+  func URLEncodingModelWithQueryString(parameters: [String: String?]?, url: String) -> Data? {
+    let url = url
+    guard let parameters = parameters else {
+      return url.data(using: .utf8)
     }
+    var arr = [String]()
+    for (key, value) in parameters {
+      guard let value = value else {
+        continue
+      }
+      arr.append("\(key)=\(value)")
+    }
+    let formDataString = arr.joined(separator: "&")
+    print(formDataString)
+    return formDataString.data(using: .utf8)
+  }
+  
+  // URLEncoding, nobody
+  func URLEncoding(parameters: [String: String?]?, url: String) -> URL? {
+    var components = URLComponents(string: url)
+    guard let parameters = parameters else {
+      return components?.url
+    }
+    var queryItems: [URLQueryItem] = []
+    for (key, value) in parameters {
+      queryItems.append(URLQueryItem(name: key, value: value))
+    }
+    components?.queryItems = queryItems
+    return components?.url
+  }
 }

--- a/MOMO/MOMO/Screen/Home/ViewController/HomeMainViewController.swift
+++ b/MOMO/MOMO/Screen/Home/ViewController/HomeMainViewController.swift
@@ -39,6 +39,7 @@ final class HomeMainViewController: UIViewController, StoryboardInstantiable, Di
   }
   
   private var currentPage = 0
+  lazy var networkManager = NetworkManager()
   lazy var customNavigationDelegate = CustomNavigationManager()
   private var datasource: [NoticeData] = [NoticeData(id: 1, author: "관리자", title: "공지사항1", url: "www.naver.com", createdAt: "2012.11.12", updatedAt: "2012.11.12"), NoticeData(id: 2, author: "관리자", title: "공지사항2", url: "www.naver.com", createdAt: "2012.11.12", updatedAt: "2012.11.12"), NoticeData(id: 3, author: "관리자", title: "공지사항3", url: "www.naver.com", createdAt: "2012.11.12", updatedAt: "2012.11.12"), NoticeData(id: 4, author: "관리자", title: "공지사항4", url: "www.naver.com", createdAt: "2012.11.12", updatedAt: "2012.11.12"), NoticeData(id: 5, author: "관리자", title: "공지사항5", url: "www.naver.com", createdAt: "2012.11.12", updatedAt: "2012.11.12")]
   
@@ -47,11 +48,45 @@ final class HomeMainViewController: UIViewController, StoryboardInstantiable, Di
     super.viewDidLoad()
     assignbackground()
     bannerTimer()
+    getNotice()
+    testPolicy()
   }
   
   override func viewDidLayoutSubviews() {
     imageHuggingView.setRound()
     babyProfileImageView.setRound()
+  }
+  
+  private func testPolicy() {
+    networkManager.request(apiModel: GetApi.policyGet(token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjksImVtYWlsIjoieWJAa2ltLmNvbSIsIm5hbWUiOiJ5YmtpbSIsImlhdCI6MTY0MDE4NjE1MCwiZXhwIjoxNjQwNDQ1MzUwLCJpc3MiOiJtb21vIn0.4TtHoK5dpdebtC8vyUc0XCMkCW3SAW9B6vz6_WgKYcU", keyword: nil, location: nil, category: "law", page: nil)) { result in
+      switch result {
+      case.success(let data):
+        let parsingmanager = ParsingManager()
+        parsingmanager.judgeGenericResponse(data: data, model: [SimpleCommunityData].self) { data in
+          print(data)
+        }
+      case .failure(let error):
+        print(error)
+      }
+    }
+  }
+  
+  private func getNotice() {
+    networkManager.request(apiModel: GetApi.noticeGet) { result in
+      switch result {
+      case.success(let data):
+        let parsingManager = ParsingManager()
+        parsingManager.judgeGenericResponse(data: data, model: [NoticeData].self) { data in
+          DispatchQueue.main.async { [weak self] in
+            guard let self = self else {return}
+            self.datasource = data
+            self.bannerCollectionView.reloadData()
+          }
+        }
+      case .failure(let error):
+        print(error)
+      }
+    }
   }
   
   private func assignbackground(){
@@ -121,8 +156,6 @@ extension HomeMainViewController: UICollectionViewDelegate, UICollectionViewData
 extension HomeMainViewController: UICollectionViewDelegateFlowLayout {
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    print(view.frame.size)
-    print(bannerCollectionView.frame.size)
     return CGSize(width: collectionView.frame.size.width, height: collectionView.frame.size.height)
   }
   


### PR DESCRIPTION
1. APIable 프로토콜 변경사항 존재
- encodingType, header의 추가
- contentType에서 URLencoding 형식 추가

2. GenericResponse, judgeGenericResponse 추가
- res로 들어오는 status, success, message에 대한 중복을 막기 위해 한번 더 감싸줌
- 또한 콜백을 달아서 통신 이후에 바로 실행될 코드를 작성하도록 둠
- 방법은 homemainVC에 존재함